### PR TITLE
KEYS: Fix keyring ref leak in join_session_keyring()

### DIFF
--- a/security/keys/process_keys.c
+++ b/security/keys/process_keys.c
@@ -792,6 +792,7 @@ long join_session_keyring(const char *name)
 		ret = PTR_ERR(keyring);
 		goto error2;
 	} else if (keyring == new->session_keyring) {
+                key_put(keyring);
 		ret = 0;
 		goto error2;
 	}


### PR DESCRIPTION
If a thread is asked to join as a session keyring the keyring that's already set as its session, we leak a keyring reference.

Source: http://review.cyanogenmod.org/#/c/129099/